### PR TITLE
Fix pinout for fast discharge pin on E73...E

### DIFF
--- a/code/b-parasite/config/prst_config.h
+++ b/code/b-parasite/config/prst_config.h
@@ -35,7 +35,12 @@
 
 // PWM.
 #define PRST_PWM_PIN NRF_GPIO_PIN_MAP(0, 5)
+
+#ifdef NRF52833_XXAA
+#define PRST_FAST_DISCH_PIN NRF_GPIO_PIN_MAP(0, 25)
+#else
 #define PRST_FAST_DISCH_PIN NRF_GPIO_PIN_MAP(1, 10)
+#endif
 
 // SHT3C temp/humidity sensor.
 #define PRST_SHT3C_DEBUG 0


### PR DESCRIPTION
As I noticed (only now...) during testing of #6 , the pinout for the E73 modules is slightly different in regard to GPIO pins. I have added a `#ifdef` to the config section where it is relevant (only the fast discharge enable pin). Turns out with it working this thing is more precise than without! :D 