### PR TITLE
Fix ADC Overflow with dark environment

### DIFF
--- a/code/b-parasite/src/prst/adc.c
+++ b/code/b-parasite/src/prst/adc.c
@@ -134,6 +134,11 @@ prst_adc_soil_moisture_t prst_adc_soil_read(double battery_voltage) {
 prst_adc_photo_sensor_t prst_adc_photo_read(double battery_voltage) {
   nrf_saadc_value_t raw_photo_output =
       sample_adc_channel(PRST_ADC_PHOTO_CHANNEL);
+
+  if (raw_photo_output < 0) {
+    raw_photo_output = 0;
+  }
+
   prst_adc_photo_sensor_t ret;
   ret.raw = raw_photo_output;
   ret.voltage = (3.6 * raw_photo_output) / (1 << PRST_ADC_RESOLUTION);


### PR DESCRIPTION
The ADC seems to return values lower than 0 in very dark situations, possibly due to noise.
If this happens, the resulting lux value is 65535, obviously inaccurate. This PR does fix that.