### PR TITLE
Add support for using the nRF52 preprogrammed random MAC address

### DIFF
--- a/code/b-parasite/config/prst_config.h
+++ b/code/b-parasite/config/prst_config.h
@@ -26,11 +26,18 @@
 // Prints out BLE debug info, such as the final encoded advertisement packet.
 #define PRST_BLE_DEBUG 0
 #define PRST_BLE_PROTOCOL_VERSION 1
-// We're using a random static MAC address, which has the following constraints:
-// 1. Two most significant bits are set to 1;
-// 2. The remaining bits should not _all_ be set to 0;
-// 2. The remaining bits should not _all_ be set to 1;
+
+// There are two options for configuring the MAC address of b-parasites:
+// 1. Comment out the PRST_BLE_MAC_ADDR to use a random static MAC address that
+// is preprogrammed in each nRF52 chip.
+// 2. Manually specify the MAC address you want below. In this scenario, the
+// following constraints must be met to ensure valid random static MAC
+// addresses:
+// a. Two most significant bits are set to 1;
+// b. The remaining bits should not _all_ be set to 0;
+// c. The remaining bits should not _all_ be set to 1;
 #define PRST_BLE_MAC_ADDR "f0:ca:f0:ca:01:01"
+
 #define PRST_BLE_ADV_NAME "prst"
 // Total time spend advertising.
 #define PRST_BLE_ADV_TIME_IN_MS 1000


### PR DESCRIPTION
Each nRF52 chip comes preprogrammed with a random static MAC address.
This is the default MAC address that is used if we don't specify one.

Fixes #25