### PR TITLE
First stab at an alternative, BTHome compatible BLE protocol

### DIFF
--- a/code/b-parasite/config/prst_config.h
+++ b/code/b-parasite/config/prst_config.h
@@ -27,9 +27,15 @@
 // BLE.
 // Prints out BLE debug info, such as the final encoded advertisement packet.
 #define PRST_BLE_DEBUG 0
-// The BLE protocol version defines how the sensors' data is encoded inside the
-// BLE advertisement packet. Possible values are 1 and 2.
-#define PRST_BLE_PROTOCOL_VERSION 1
+
+// Supported BLE protocols.
+// Default, custom BLE protocol.
+#define PRST_BLE_PROTOCOL_BPARASITE_V2 0x01
+// BTHome BLE protocol - https://bthome.io.
+#define PRST_BLE_PROTOCOL_BTHOME 0x02
+
+// Chosen BLE protocol.
+#define PRST_BLE_PROTOCOL PRST_BLE_PROTOCOL_BPARASITE_V2
 
 // There are two options for configuring the MAC address of b-parasites:
 // 1. Comment out the PRST_BLE_MAC_ADDR to use a random static MAC address that

--- a/code/b-parasite/src/main.c
+++ b/code/b-parasite/src/main.c
@@ -9,6 +9,7 @@
 #include "nrf_pwr_mgmt.h"
 #include "prst/adc.h"
 #include "prst/ble.h"
+#include "prst/data.h"
 #include "prst/pwm.h"
 #include "prst/rtc.h"
 #include "prst/shtc3.h"
@@ -86,9 +87,16 @@ static void rtc_callback() {
     nrf_gpio_pin_clear(PRST_PHOTO_V_PIN);
 #endif
 
-    prst_ble_update_adv_data(batt_read.millivolts, temp_humi.temp_celsius,
-                             temp_humi.humidity, soil_read.relative, lux,
-                             run_counter);
+    prst_sensor_data_t sensors = {
+        .batt_mv = batt_read.millivolts,
+        .temp_c = temp_humi.temp_celsius,
+        .humi = temp_humi.humidity,
+        .soil_moisture = soil_read.relative,
+        .lux = lux,
+        .run_counter = run_counter,
+    };
+
+    prst_ble_update_adv_data(&sensors);
 
     state = ADVERTISING;
     prst_adv_start();

--- a/code/b-parasite/src/prst/ble.c
+++ b/code/b-parasite/src/prst/ble.c
@@ -210,8 +210,8 @@ static void set_service_data_bthome_protocol(
   // 1. Soil moisture.
   // uint16_t.
   service_data[0] = (0b000 << 5) | 2;
-  // Type of measurement. Temporarily using humidity.
-  service_data[1] = 0x03;
+  // Type of measurement - Moisture.
+  service_data[1] = 0x14;
   // Value. Factor of 0.01, so we need to multiply our the value in 100% by
   // 1/0.01 = 100.
   uint16_t soil_val = (10000 * sensors->soil_moisture) / UINT16_MAX;
@@ -248,16 +248,16 @@ static void set_service_data_bthome_protocol(
   service_data[14] = batt_val & 0xff;
   service_data[15] = batt_val >> 8;
 
-  // 5. Illuminance
-  // uint24_t.
-  service_data[16] = (0b000 << 5) | 2;
-  // Type - illuminance.
-  service_data[17] = 0x05;
-  // Value. Factor 0.01.
-  uint32_t illu_value = 100 * sensors->lux;
-  service_data[18] = illu_value & 0xff;
-  service_data[19] = (illu_value >> 8) & 0xff;
-  service_data[20] = (illu_value >> 16) & 0xff;
+  // // 5. Illuminance
+  // // uint24_t.
+  // service_data[16] = (0b000 << 5) | 2;
+  // // Type - illuminance.
+  // service_data[17] = 0x05;
+  // // Value. Factor 0.01.
+  // uint32_t illu_value = 100 * sensors->lux;
+  // service_data[18] = illu_value & 0xff;
+  // service_data[19] = (illu_value >> 8) & 0xff;
+  // service_data[20] = (illu_value >> 16) & 0xff;
 }
 #endif  // PRST_BLE_PROTOCOL == PRST_BLE_PROTOCOL_BTHOME
 

--- a/code/b-parasite/src/prst/ble.c
+++ b/code/b-parasite/src/prst/ble.c
@@ -48,7 +48,7 @@ prst_config.h.
 #define SERVICE_DATA_LEN 18
 #elif PRST_BLE_PROTOCOL == PRST_BLE_PROTOCOL_BTHOME
 #define SERVICE_UUID 0x181c
-#define SERVICE_DATA_LEN 21
+#define SERVICE_DATA_LEN 16
 #else
 #error "PRST_BLE_PROTOCOL is not properly configured"
 #endif
@@ -233,8 +233,8 @@ static void set_service_data_bthome_protocol(
   service_data[8] = (0b000 << 5) | 2;
   // Type - humidity.
   service_data[9] = 0x03;
-  // Value. Factor 0.01.
-  uint16_t humi_val = (100 * sensors->humi) / UINT16_MAX;
+  // Value. Factor 0.01, over 100%.
+  uint16_t humi_val = (10000 * sensors->humi) / UINT16_MAX;
   service_data[10] = humi_val & 0xff;
   service_data[11] = humi_val >> 8;
 
@@ -247,17 +247,6 @@ static void set_service_data_bthome_protocol(
   uint16_t batt_val = sensors->batt_mv;
   service_data[14] = batt_val & 0xff;
   service_data[15] = batt_val >> 8;
-
-  // // 5. Illuminance
-  // // uint24_t.
-  // service_data[16] = (0b000 << 5) | 2;
-  // // Type - illuminance.
-  // service_data[17] = 0x05;
-  // // Value. Factor 0.01.
-  // uint32_t illu_value = 100 * sensors->lux;
-  // service_data[18] = illu_value & 0xff;
-  // service_data[19] = (illu_value >> 8) & 0xff;
-  // service_data[20] = (illu_value >> 16) & 0xff;
 }
 #endif  // PRST_BLE_PROTOCOL == PRST_BLE_PROTOCOL_BTHOME
 

--- a/code/b-parasite/src/prst/ble.h
+++ b/code/b-parasite/src/prst/ble.h
@@ -4,6 +4,8 @@
 #include <app_error.h>
 #include <stdint.h>
 
+#include "prst/data.h"
+
 // Initializes SoftDevice.
 void prst_ble_init();
 
@@ -11,8 +13,6 @@ void prst_adv_start();
 
 void prst_adv_stop();
 
-void prst_ble_update_adv_data(uint16_t batt_millivolts, float temp_celsius,
-                              uint16_t humidity, uint16_t soil_moisture,
-                              uint16_t brightness, uint8_t run_counter);
+void prst_ble_update_adv_data(const prst_sensor_data_t* sensors);
 
 #endif  // _PRST_BLE_H_

--- a/code/b-parasite/src/prst/data.h
+++ b/code/b-parasite/src/prst/data.h
@@ -1,0 +1,15 @@
+#ifndef _PRST_DATA_H_
+#define _PRST_DATA_H_
+
+#include <stdint.h>
+
+typedef struct {
+  uint16_t batt_mv;
+  float temp_c;
+  uint16_t humi;
+  uint16_t soil_moisture;
+  uint16_t lux;
+  uint8_t run_counter;
+} prst_sensor_data_t;
+
+#endif  // _PRST_DATA_H_


### PR DESCRIPTION
This protococol (https://bthome.io/) allows for automatic sensor
detection in Home Assistant, as long as the device broadcasts its
sensors in the expected format.