### PR TITLE
Fix ADC config for nRF52833

### DIFF
--- a/code/nrf-connect/prstlib/boards/arm/bparasite_nrf52833/bparasite_nrf52833.dts
+++ b/code/nrf-connect/prstlib/boards/arm/bparasite_nrf52833/bparasite_nrf52833.dts
@@ -13,7 +13,7 @@
 	};
 
 	zephyr,user {
-		io-channels = <&adc 0>, <&adc 1>, <&adc 2>;
+		io-channels = <&adc 0>, <&adc 2>;
 	};
 
 	leds {
@@ -43,7 +43,7 @@
 		compatible = "gpio-keys";
 		fast_disch: fast_disch {
 			// P0.25.
-			gpios = <&gpio1 10 GPIO_ACTIVE_HIGH>;
+			gpios = <&gpio0 25 GPIO_ACTIVE_HIGH>;
 			label = "Fast discharge circuitry";
 		};
 	};
@@ -106,17 +106,6 @@
 		zephyr,input-positive = <NRF_SAADC_AIN1>;
 		zephyr,resolution = <10>;
 
-	};
-
-	// Photo.
-	channel@1 {
-		reg = <1>;
-		zephyr,gain = "ADC_GAIN_1_6";
-		zephyr,reference = "ADC_REF_INTERNAL";
-		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
-		// P0.02.
-		zephyr,input-positive = <NRF_SAADC_AIN0>;
-		zephyr,resolution = <10>;
 	};
 
 	// Battery.

--- a/code/nrf-connect/prstlib/boards/arm/bparasite_nrf52833/bparasite_nrf52833_1_1_0.overlay
+++ b/code/nrf-connect/prstlib/boards/arm/bparasite_nrf52833/bparasite_nrf52833_1_1_0.overlay
@@ -12,7 +12,7 @@
 		ldr_enable: ldr_enable {
 			// P0.29.
 			gpios = <&gpio0 29 GPIO_ACTIVE_HIGH>;
-			label = "Fast discharge circuitry";
+			label = "LDR supply";
 		};
 	};
 };

--- a/code/nrf-connect/prstlib/boards/arm/bparasite_nrf52833/bparasite_nrf52833_1_2_0.overlay
+++ b/code/nrf-connect/prstlib/boards/arm/bparasite_nrf52833/bparasite_nrf52833_1_2_0.overlay
@@ -11,7 +11,7 @@
 		photo_transistor_enable: photo_transistor_enable {
 			// P0.29.
 			gpios = <&gpio0 29 GPIO_ACTIVE_HIGH>;
-			label = "Fast discharge circuitry";
+			label = "Phototransistor supply";
 		};
 	};
 };

--- a/code/nrf-connect/prstlib/boards/arm/bparasite_nrf52840/bparasite_nrf52840.dts
+++ b/code/nrf-connect/prstlib/boards/arm/bparasite_nrf52840/bparasite_nrf52840.dts
@@ -13,7 +13,7 @@
 	};
 
 	zephyr,user {
-		io-channels = <&adc 0>,  <&adc 2>;
+		io-channels = <&adc 0>, <&adc 2>;
 	};
 
 	leds {

--- a/code/nrf-connect/prstlib/boards/arm/bparasite_nrf52840/bparasite_nrf52840_1_1_0.overlay
+++ b/code/nrf-connect/prstlib/boards/arm/bparasite_nrf52840/bparasite_nrf52840_1_1_0.overlay
@@ -12,7 +12,7 @@
 		ldr_enable: ldr_enable {
 			// P0.29.
 			gpios = <&gpio0 29 GPIO_ACTIVE_HIGH>;
-			label = "Fast discharge circuitry";
+			label = "LDR supply";
 		};
 	};
 };

--- a/code/nrf-connect/prstlib/boards/arm/bparasite_nrf52840/bparasite_nrf52840_1_2_0.overlay
+++ b/code/nrf-connect/prstlib/boards/arm/bparasite_nrf52840/bparasite_nrf52840_1_2_0.overlay
@@ -11,7 +11,7 @@
 		photo_transistor_enable: photo_transistor_enable {
 			// P0.29.
 			gpios = <&gpio0 29 GPIO_ACTIVE_HIGH>;
-			label = "Fast discharge circuitry";
+			label = "Phototransistor supply";
 		};
 	};
 };


### PR DESCRIPTION
Potentially fixes the nRF52833 DTS ADC definitions, raised in #76.

@jhbruhn I found a couple of bugs that would explain the ADC errors you're seeing, including the wrong pin config you pointed out. I've ordered myself a couple of nRF52833 for testing. It will take some time to arrive, so unfortunately I can't test these myself, but at least now the config seems to be on par with the nRF52840 variant. Let me know if you manage to take it for spin. Tks!