### PR TITLE
Fix: Counter was missing

### DIFF
--- a/code/nrf-connect/samples/ble/src/encoding.c
+++ b/code/nrf-connect/samples/ble/src/encoding.c
@@ -24,7 +24,10 @@ int prst_ble_encode_service_data(const prst_sensors_t* sensors,
 #endif
   // 4 bits for a small wrap-around counter for deduplicating messages on the
   // receiver.
-  // out[3] = sensors->run_counter & 0x0f;
+
+  static uint8_t run_counter;
+
+  out[3] = run_counter++ & 0x0f;
   out[4] = sensors->batt.adc_read.millivolts >> 8;
   out[5] = sensors->batt.adc_read.millivolts & 0xff;
   int16_t temp_centicelsius = 100 * sensors->shtc3.temp_c;


### PR DESCRIPTION
The counter in the classic b-parasite protocol was missing. This led to the parasite-scanner and esphome implementation to ignore the ble updates. This fixes the problem for me.

Tested with parasite-scanner and esphome