### PR TITLE
Zigbee schedule steering restart

### DIFF
--- a/code/nrf-connect/samples/zigbee/CMakeLists.txt
+++ b/code/nrf-connect/samples/zigbee/CMakeLists.txt
@@ -16,6 +16,7 @@ target_sources(app PRIVATE
   src/factory_reset.c
   src/prst_zb_attrs.c
   src/prst_zb_soil_moisture_defs.c
+  src/restart_handler.c
 )
 
 add_subdirectory(../../prstlib prstlib)

--- a/code/nrf-connect/samples/zigbee/Kconfig
+++ b/code/nrf-connect/samples/zigbee/Kconfig
@@ -32,3 +32,7 @@ config PRST_ZB_FACTORY_RESET_VIA_RESET_PIN
   bool "Resetting via the reset pin will factory reset the device. Power cycling through battery replacement will not."
 
 endchoice  # PRST_ZB_FACTORY_RESET_METHOD
+
+config PRST_ZB_RESTART_WATCHDOG_TIMEOUT_SEC
+    int "Duration after the device will restart the rejoin procedure if a network has not been successfully joined."
+    default 3600

--- a/code/nrf-connect/samples/zigbee/src/main.c
+++ b/code/nrf-connect/samples/zigbee/src/main.c
@@ -140,6 +140,7 @@ void zboss_signal_handler(zb_bufid_t bufid) {
       break;
     case ZB_ZDO_SIGNAL_LEAVE:
       if (status == RET_OK) {
+        k_timer_start(&led_flashing_timer, K_NO_WAIT, K_SECONDS(1));
         zb_zdo_signal_leave_params_t *leave_params = ZB_ZDO_SIGNAL_GET_PARAMS(sig_hndler, zb_zdo_signal_leave_params_t);
         LOG_INF("Network left (leave type: %d)", leave_params->leave_type);
 
@@ -150,7 +151,7 @@ void zboss_signal_handler(zb_bufid_t bufid) {
       }
     case ZB_ZDO_SIGNAL_SKIP_STARTUP: {
       stack_initialised = true;
-      LOG_DBG("Will restart flashing");
+      LOG_DBG("Started zigbee stack and waiting for connection to network.");
       k_timer_start(&led_flashing_timer, K_NO_WAIT, K_SECONDS(1));
       break;
     }

--- a/code/nrf-connect/samples/zigbee/src/main.c
+++ b/code/nrf-connect/samples/zigbee/src/main.c
@@ -36,8 +36,6 @@ static void led_flashing_cb(struct k_timer *timer) {
 
 K_TIMER_DEFINE(led_flashing_timer, led_flashing_cb, /*stop_fn=*/NULL);
 
-extern struct k_timer restart_timer;
-
 ZB_ZCL_DECLARE_IDENTIFY_ATTRIB_LIST(
     identify_attr_list,
     &dev_ctx.identify_attr.identify_time);
@@ -135,12 +133,12 @@ void zboss_signal_handler(zb_bufid_t bufid) {
         LOG_DBG("Steering successful. Status: %d", status);
         prst_led_flash(/*times=*/3);
         k_timer_stop(&led_flashing_timer);
-        k_timer_stop(&restart_timer);
+        prst_restart_watchdog_stop();
         prst_led_off();
       } else {
         LOG_DBG("Steering failed. Status: %d", status);
         prst_led_flash(7);
-        k_timer_start(&restart_timer, K_SECONDS(PRST_ZB_RESET_TIMEOUT), K_MSEC(0));
+        prst_restart_watchdog_start();
         k_timer_stop(&led_flashing_timer);  // Power saving
         prst_led_off();
       }

--- a/code/nrf-connect/samples/zigbee/src/main.c
+++ b/code/nrf-connect/samples/zigbee/src/main.c
@@ -128,8 +128,9 @@ void zboss_signal_handler(zb_bufid_t bufid) {
     case ZB_BDB_SIGNAL_STEERING:         // New network.
     case ZB_BDB_SIGNAL_DEVICE_REBOOT: {  // Previously joined network.
       LOG_DBG("Steering complete. Status: %d", status);
-      prst_led_flash(/*times=*/3);
       if (status == RET_OK) {
+        LOG_DBG("Steering successful. Status: %d", status);
+        prst_led_flash(/*times=*/3);
         k_timer_stop(&led_flashing_timer);
         prst_led_off();
       }

--- a/code/nrf-connect/samples/zigbee/src/main.c
+++ b/code/nrf-connect/samples/zigbee/src/main.c
@@ -141,8 +141,8 @@ void zboss_signal_handler(zb_bufid_t bufid) {
         LOG_DBG("Steering failed. Status: %d", status);
         prst_led_flash(7);
         k_timer_start(&restart_timer, K_SECONDS(PRST_ZB_RESET_TIMEOUT), K_MSEC(0));
-        k_timer_stop(&led_flashing_timer); // Power saving
-        prst_led_off(); 
+        k_timer_stop(&led_flashing_timer);  // Power saving
+        prst_led_off();
       }
     }
     case ZB_BDB_SIGNAL_DEVICE_FIRST_START:

--- a/code/nrf-connect/samples/zigbee/src/restart_handler.c
+++ b/code/nrf-connect/samples/zigbee/src/restart_handler.c
@@ -1,14 +1,14 @@
-#include <zephyr/logging/log.h>
-#include <zephyr/kernel.h>
-#include <zigbee/zigbee_app_utils.h>
-
 #include "restart_handler.h"
+
+#include <zephyr/kernel.h>
+#include <zephyr/logging/log.h>
+#include <zigbee/zigbee_app_utils.h>
 
 LOG_MODULE_REGISTER(restart_handler, CONFIG_LOG_DEFAULT_LEVEL);
 
 static void restart_network_steering_cb(struct k_timer *timer) {
-    LOG_DBG("Restart handler expired. Restarting network steering.");
-    user_input_indicate();
+  LOG_DBG("Restart handler expired. Restarting network steering.");
+  user_input_indicate();
 }
 
 K_TIMER_DEFINE(restart_timer, restart_network_steering_cb, NULL);

--- a/code/nrf-connect/samples/zigbee/src/restart_handler.c
+++ b/code/nrf-connect/samples/zigbee/src/restart_handler.c
@@ -8,6 +8,7 @@ LOG_MODULE_REGISTER(restart_handler, CONFIG_LOG_DEFAULT_LEVEL);
 
 static void restart_network_steering_cb(struct k_timer *timer) {
   LOG_DBG("Restart handler expired. Restarting network steering.");
+  // If the device is not commissioned, the rejoin procedure is started.
   user_input_indicate();
 }
 

--- a/code/nrf-connect/samples/zigbee/src/restart_handler.c
+++ b/code/nrf-connect/samples/zigbee/src/restart_handler.c
@@ -14,10 +14,10 @@ static void restart_network_steering_cb(struct k_timer *timer) {
 
 K_TIMER_DEFINE(restart_timer, restart_network_steering_cb, NULL);
 
-static void prst_restart_watchdog_start() {
-  k_timer_start(&restart_timer, K_SECONDS(PRST_ZB_RESET_TIMEOUT), K_MSEC(0));
+void prst_restart_watchdog_start() {
+  k_timer_start(&restart_timer, K_SECONDS(CONFIG_PRST_ZB_RESTART_WATCHDOG_TIMEOUT_SEC), K_MSEC(0));
 }
 
-static void prst_restart_watchdog_stop() {
+void prst_restart_watchdog_stop() {
   k_timer_stop(&restart_timer);
 }

--- a/code/nrf-connect/samples/zigbee/src/restart_handler.c
+++ b/code/nrf-connect/samples/zigbee/src/restart_handler.c
@@ -13,3 +13,11 @@ static void restart_network_steering_cb(struct k_timer *timer) {
 }
 
 K_TIMER_DEFINE(restart_timer, restart_network_steering_cb, NULL);
+
+static void prst_restart_watchdog_start() {
+  k_timer_start(&restart_timer, K_SECONDS(PRST_ZB_RESET_TIMEOUT), K_MSEC(0));
+}
+
+static void prst_restart_watchdog_stop() {
+  k_timer_stop(&restart_timer);
+}

--- a/code/nrf-connect/samples/zigbee/src/restart_handler.c
+++ b/code/nrf-connect/samples/zigbee/src/restart_handler.c
@@ -1,0 +1,14 @@
+#include <zephyr/logging/log.h>
+#include <zephyr/kernel.h>
+#include <zigbee/zigbee_app_utils.h>
+
+#include "restart_handler.h"
+
+LOG_MODULE_REGISTER(restart_handler, CONFIG_LOG_DEFAULT_LEVEL);
+
+static void restart_network_steering_cb(struct k_timer *timer) {
+    LOG_DBG("Restart handler expired. Restarting network steering.");
+    user_input_indicate();
+}
+
+K_TIMER_DEFINE(restart_timer, restart_network_steering_cb, NULL);

--- a/code/nrf-connect/samples/zigbee/src/restart_handler.h
+++ b/code/nrf-connect/samples/zigbee/src/restart_handler.h
@@ -1,0 +1,6 @@
+#ifndef _PRST_ZB_RESTART_HANDLER_H_
+#define _PRST_ZB_RESTART_HANDLER_H_
+
+static const int PRST_ZB_RESET_TIMEOUT = 5 * 60;
+
+#endif // _PRST_ZB_RESTART_HANDLER_H_

--- a/code/nrf-connect/samples/zigbee/src/restart_handler.h
+++ b/code/nrf-connect/samples/zigbee/src/restart_handler.h
@@ -1,9 +1,7 @@
 #ifndef _PRST_ZB_RESTART_HANDLER_H_
 #define _PRST_ZB_RESTART_HANDLER_H_
 
-static const int PRST_ZB_RESET_TIMEOUT = 5 * 60;
-
-static void prst_restart_watchdog_start;
-static void prst_restart_watchdog_stop;
+void prst_restart_watchdog_start();
+void prst_restart_watchdog_stop();
 
 #endif  // _PRST_ZB_RESTART_HANDLER_H_

--- a/code/nrf-connect/samples/zigbee/src/restart_handler.h
+++ b/code/nrf-connect/samples/zigbee/src/restart_handler.h
@@ -3,4 +3,7 @@
 
 static const int PRST_ZB_RESET_TIMEOUT = 5 * 60;
 
+static void prst_restart_watchdog_start;
+static void prst_restart_watchdog_stop;
+
 #endif  // _PRST_ZB_RESTART_HANDLER_H_

--- a/code/nrf-connect/samples/zigbee/src/restart_handler.h
+++ b/code/nrf-connect/samples/zigbee/src/restart_handler.h
@@ -3,4 +3,4 @@
 
 static const int PRST_ZB_RESET_TIMEOUT = 5 * 60;
 
-#endif // _PRST_ZB_RESTART_HANDLER_H_
+#endif  // _PRST_ZB_RESTART_HANDLER_H_


### PR DESCRIPTION
From the discussion in #126 

This PR implements a timer based mechanism to restart networt steering if the previous steering procedure was not successful. This change will improve the reliability with reconnecting to the network e.g. in cases of power losses or being located at the edge of the network.

Zephyr does only try to reconnect to the network a finite amount of times for end devices. It does so with exponential back of for around 15 minutes. This behaviour is hard coded into Zephyr and not easily changeable.

The official docs suggest reinitializing the steering process by either power cycling the device or via provided method `user_input_indicate()`.

The PR is meant for a basis for discussion and further improvements.

I tried to keep the `main.c` as clean as possible by moving the code to separate files. My C knowledge is somewhat limited and maybe there is a better way of doing this.

I adjusted some LED blinking to reduce blinking in case of network loss to reduce power draw.

The firmware runs on a few parasites in my setup for almost two months now and proves to be quite reliable.