### PR TITLE
Fix (minor?) issues with the ZigBee sample

### DIFF
--- a/code/nrf-connect/samples/zigbee/Kconfig
+++ b/code/nrf-connect/samples/zigbee/Kconfig
@@ -7,7 +7,7 @@ config PRST_ZB_SLEEP_DURATION_SEC
 
 config PRST_ZB_PARENT_POLL_INTERVAL_SEC
 	int "Interval for when b-parasite polls its parent for data in seconds."
-	default 60
+	default 10
 
 config PRST_ZB_BUILD_DATE
   string "Zigbee basic cluster build date attribute. Max 16 bytes."

--- a/code/nrf-connect/samples/zigbee/Kconfig
+++ b/code/nrf-connect/samples/zigbee/Kconfig
@@ -34,6 +34,9 @@ config PRST_ZB_FACTORY_RESET_VIA_RESET_PIN
 config PRST_ZB_FACTORY_RESET_VIA_SW1
   bool "Resetting while pressing and holding SW1 for 5 seconds will factory reset the device. Only available on v2.0.0+ hardware revisions."
 
+config PRST_ZB_FACTORY_RESET_DISABLED
+  bool "No factory reset procedure."
+
 endchoice  # PRST_ZB_FACTORY_RESET_METHOD
 
 config PRST_ZB_RESTART_WATCHDOG_TIMEOUT_SEC

--- a/code/nrf-connect/samples/zigbee/prj.conf
+++ b/code/nrf-connect/samples/zigbee/prj.conf
@@ -8,9 +8,6 @@ CONFIG_GPIO=y
 CONFIG_USE_SEGGER_RTT=y
 CONFIG_SEGGER_RTT_BUFFER_SIZE_UP=4096
 
-CONFIG_PM=y
-CONFIG_PM_DEVICE=y
-
 CONFIG_NEWLIB_LIBC=y
 CONFIG_NEWLIB_LIBC_FLOAT_PRINTF=y
 
@@ -39,8 +36,17 @@ CONFIG_NET_IPV6_RA_RDNSS=n
 CONFIG_NET_IP_ADDR_CHECK=n
 CONFIG_NET_UDP=n
 
+##
+## ZigBee Channel Selection
+##
 # Get Zigbee to scan every channel.
 CONFIG_ZIGBEE_CHANNEL_SELECTION_MODE_MULTI=y
+# By default only scans channel 11 (ZigBee2MQTT default) and 15 (ZHA default).
+# Comment to scan all channels - this will make pairing consume more energy.
+# CONFIG_ZIGBEE_CHANNEL_MASK=0x8800
+
+# Uncomment to set a specific channel - this will make pairing more energy efficient.
+# CONFIG_ZIGBEE_CHANNEL=11
 
 # Enable API for powering down unused RAM parts.
 # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/1.7.1/nrf/ug_zigbee_configuring.html#power-saving-during-sleep
@@ -60,4 +66,3 @@ CONFIG_FILE_SYSTEM_LITTLEFS=y
 # Factory reset method selection. Only hardware revision 2.0.0+ has button SW1. Earlier
 # revisions must select a different method. See Kconfig for options.
 # CONFIG_PRST_ZB_FACTORY_RESET_VIA_SW1=y
-CONFIG_PRST_ZB_FACTORY_RESET_DISABLED=y

--- a/code/nrf-connect/samples/zigbee/prj.conf
+++ b/code/nrf-connect/samples/zigbee/prj.conf
@@ -60,3 +60,4 @@ CONFIG_FILE_SYSTEM_LITTLEFS=y
 # Factory reset method selection. Only hardware revision 2.0.0+ has button SW1. Earlier
 # revisions must select a different method. See Kconfig for options.
 # CONFIG_PRST_ZB_FACTORY_RESET_VIA_SW1=y
+CONFIG_PRST_ZB_FACTORY_RESET_DISABLED=y

--- a/code/nrf-connect/samples/zigbee/src/debug_counters.c
+++ b/code/nrf-connect/samples/zigbee/src/debug_counters.c
@@ -65,6 +65,7 @@ int prst_debug_counters_increment(const char* counter_name) {
   if (written != sizeof(value)) {
     LOG_ERR("fs_write returned %d, expected %d", written, sizeof(value));
   }
+  RET_IF_ERR(fs_sync(&file));
   return fs_close(&file);
 }
 

--- a/code/nrf-connect/samples/zigbee/src/factory_reset.c
+++ b/code/nrf-connect/samples/zigbee/src/factory_reset.c
@@ -66,6 +66,7 @@ int prst_zb_factory_reset_check() {
     LOG_DBG("SW1 pressed. Scheduling timer");
     k_timer_start(&sw1_factory_reset_check_timer, K_SECONDS(5), K_NO_WAIT);
   }
-#endif
+#elif CONFIG_PRST_ZB_FACTORY_RESET_DISABLED
   return 0;
+#endif  // CONFIG_PRST_ZB_FACTORY_RESET_VIA_RESET_PIN
 }

--- a/code/nrf-connect/samples/zigbee/src/factory_reset.c
+++ b/code/nrf-connect/samples/zigbee/src/factory_reset.c
@@ -66,7 +66,10 @@ int prst_zb_factory_reset_check() {
     LOG_DBG("SW1 pressed. Scheduling timer");
     k_timer_start(&sw1_factory_reset_check_timer, K_SECONDS(5), K_NO_WAIT);
   }
+  return 0;
 #elif CONFIG_PRST_ZB_FACTORY_RESET_DISABLED
   return 0;
+#else
+#error "No factory reset method selected -- explicitly select CONFIG_PRST_ZB_FACTORY_RESET_DISABLED=y to disable it"
 #endif  // CONFIG_PRST_ZB_FACTORY_RESET_VIA_RESET_PIN
 }

--- a/code/nrf-connect/samples/zigbee/src/main.c
+++ b/code/nrf-connect/samples/zigbee/src/main.c
@@ -198,11 +198,13 @@ void update_sensors_cb(zb_uint8_t arg) {
                         /*param=*/0,
                         ZB_TIME_ONE_SECOND * CONFIG_PRST_ZB_SLEEP_DURATION_SEC);
 
+  prst_debug_counters_increment("sensors_read_before");
   if (prst_sensors_read_all(&sensors)) {
     prst_debug_counters_increment("sensors_read_error");
     LOG_ERR("Unable to read sensors");
     return;
   }
+  prst_debug_counters_increment("sensors_read_after");
 
   // Battery voltage in units of 100 mV.
   uint8_t batt_voltage = sensors.batt.adc_read.millivolts / 100;

--- a/code/nrf-connect/samples/zigbee/src/main.c
+++ b/code/nrf-connect/samples/zigbee/src/main.c
@@ -126,9 +126,14 @@ void update_sensors_cb(zb_uint8_t arg) {
   LOG_INF("Updating sensors");
 
   // Reschedule the same callback.
-  ZB_SCHEDULE_APP_ALARM(update_sensors_cb,
-                        /*param=*/0,
-                        ZB_MILLISECONDS_TO_BEACON_INTERVAL(1000 * CONFIG_PRST_ZB_SLEEP_DURATION_SEC));
+  zb_ret_t ret = ZB_SCHEDULE_APP_ALARM(
+      update_sensors_cb,
+      /*param=*/0,
+      ZB_MILLISECONDS_TO_BEACON_INTERVAL(1000 * CONFIG_PRST_ZB_SLEEP_DURATION_SEC));
+  if (ret != RET_OK) {
+    prst_debug_counters_increment("sens_cb_schedule_err");
+    zb_reset(0);
+  }
 
   prst_debug_counters_increment("sensors_read_before");
   if (prst_sensors_read_all(&sensors)) {

--- a/code/nrf-connect/samples/zigbee/src/main.c
+++ b/code/nrf-connect/samples/zigbee/src/main.c
@@ -123,7 +123,7 @@ void identify_cb(zb_bufid_t bufid) {
 }
 
 void update_sensors_cb(zb_uint8_t arg) {
-  LOG_INF("Updating sensors");
+  LOG_DBG("Updating sensors");
 
   // Reschedule the same callback.
   zb_ret_t ret = ZB_SCHEDULE_APP_ALARM(
@@ -256,7 +256,7 @@ void zboss_signal_handler(zb_bufid_t bufid) {
 }
 
 void log_counter(const char *counter_name, prst_debug_counter_t value) {
-  LOG_DBG("- %s: %d", counter_name, value);
+  LOG_INF("- %s: %d", counter_name, value);
 }
 
 int main(void) {
@@ -271,7 +271,7 @@ int main(void) {
 
   prst_debug_counters_increment("boot");
 
-  LOG_DBG("Dumping debug counters:");
+  LOG_INF("Dumping debug counters:");
   prst_debug_counters_get_all(log_counter);
 
   RET_IF_ERR(prst_zb_factory_reset_check());

--- a/code/nrf-connect/samples/zigbee/src/main.c
+++ b/code/nrf-connect/samples/zigbee/src/main.c
@@ -196,6 +196,7 @@ void zboss_signal_handler(zb_bufid_t bufid) {
         prst_restart_watchdog_start();
         // Power saving.
         k_timer_stop(&led_flashing_timer);
+        prst_led_off();
       }
       joining_signal_received = true;
       break;

--- a/code/nrf-connect/samples/zigbee/src/restart_handler.c
+++ b/code/nrf-connect/samples/zigbee/src/restart_handler.c
@@ -11,7 +11,7 @@ LOG_MODULE_REGISTER(restart_handler, CONFIG_LOG_DEFAULT_LEVEL);
 void callback_work_handler(struct k_work *work) {
   LOG_INF("Running restart callback_work_handler.");
   prst_debug_counters_increment("steering_watchdog_restart");
-  zb_reset(0);
+  user_input_indicate();
 }
 
 K_WORK_DEFINE(callback_work, callback_work_handler);

--- a/code/nrf-connect/samples/zigbee/src/restart_handler.c
+++ b/code/nrf-connect/samples/zigbee/src/restart_handler.c
@@ -11,8 +11,7 @@ LOG_MODULE_REGISTER(restart_handler, CONFIG_LOG_DEFAULT_LEVEL);
 void callback_work_handler(struct k_work *work) {
   LOG_INF("Running restart callback_work_handler.");
   prst_debug_counters_increment("steering_watchdog_restart");
-  // If the device is not commissioned, the rejoin procedure is started.
-  user_input_indicate();
+  zb_reset(0);
 }
 
 K_WORK_DEFINE(callback_work, callback_work_handler);

--- a/code/nrf-connect/samples/zigbee/src/restart_handler.c
+++ b/code/nrf-connect/samples/zigbee/src/restart_handler.c
@@ -11,6 +11,7 @@ LOG_MODULE_REGISTER(restart_handler, CONFIG_LOG_DEFAULT_LEVEL);
 void callback_work_handler(struct k_work *work) {
   LOG_INF("Running restart callback_work_handler.");
   prst_debug_counters_increment("steering_watchdog_restart");
+  // If the device is not commissioned, the rejoin procedure is started.
   user_input_indicate();
 }
 


### PR DESCRIPTION
1. `zigbee_configure_sleepy_behavior` must be called before `zigbee_enable` - [source docs](https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/libraries/zigbee/zigbee_app_utils.html#c.zigbee_configure_sleepy_behavior)
2. `zb_zdo_pim_set_long_poll_interval` must be called after the network is joined - [source docs](https://developer.nordicsemi.com/nRF_Connect_SDK/doc/zboss/3.5.2.0/group__zdo__poll__control.html#ga3aae8929b30e71c872f937771b89c768). On top of that, the argument for the call was incorrect - it expects ms directly. Lowered the default to 10 ms, which is already double the previously working value of 5 ms (SDK default). 
3. Removed the unnecessary `CONFIG_PM`, `CONFIG_PM_DEVICE`. It seems like there's no impact in power consumption. Could it cause some of the weirdness we've seen in #126, #130?
4. Implemented `CONFIG_PRST_ZB_FACTORY_RESET_DISABLED=y` to fully disable factory resetting. May aid debugging.
5. Added comment on `prj.conf` on how to use multi/single channel scanning. Helps with battery life when scanning networks - see power profiling below.
6. 🚨 Missing `break` statements in `zboss_signal_handler`
7. Makes `zboss_signal_handler` return fast. According to the [docs](https://infocenter.nordicsemi.com/index.jsp?topic=%2Fcom.nordic.infocenter.thread_zigbee.v2.0.0%2Fgroup__zb__comm__signals.html): "Signal processing should not do long operations synchronously". I removed calls to `prst_led_flash` (essentially a huge synchronous looping delay -- yikes) and `debug_counters_increment`, which were blocking. I'll try migrating the `debug_counters` to non-blocking separately, but got rid altogether for now
8. Main sensor reading task is started for the first time upon the `ZB_ZDO_SIGNAL_SKIP_STARTUP` signal. This is what the [weather_station sample](https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/applications/zigbee_weather_station/README.html) does. It should have no functional difference, but there's at least [some special handling for alarms started from the ZigBee task](https://github.com/nrfconnect/sdk-nrf/blob/0469247dc45b64f5657270ee02254ec5de692811/subsys/zigbee/osif/zb_nrf_platform.c#L426), so let's try that.
9. Hard `zb_reset()` if the recurring sensor reading task cannot reschedule itself with `ZB_SCHEDULE_APP_ALARM()`. "This should never happen" -- famous last words

# Power Profiling
## Long Poll Connection Interval fixed
Now we can see the 10 ms intervals between radio activity spikes:
![ppk-20230627T073821-fixed-polling](https://github.com/rbaron/b-parasite/assets/1573409/0405018e-9129-4424-9a00-f5bd31a84a8a)

## Multi Channel Network Scanning
With this (default) config, all 16 channels are scanned, causing a ~10 mA average current for a few minutes:
![ppk-20230626T075344-multichannel-default-handler-pairing](https://github.com/rbaron/b-parasite/assets/1573409/80974926-cad2-4ff0-be3f-98e1a8f05379)

## Single Channel Network Scanning
With a single configured channel, we can even see the SDK exponential backoff during scanning, which averages at a much lower current:
![ppk-20230626T060359-single-channel-pairing](https://github.com/rbaron/b-parasite/assets/1573409/a1b70a45-98dd-4935-b583-b51c6b489e9c)
