### PR TITLE
[ZigBee sample] Implements factory reset via SW1 button (hardware v2.0.0+)

### DIFF
--- a/code/nrf-connect/samples/zigbee/Kconfig
+++ b/code/nrf-connect/samples/zigbee/Kconfig
@@ -23,13 +23,16 @@ config PRST_ZB_HARDWARE_VERSION
 
 choice PRST_ZB_FACTORY_RESET_METHOD
   bool "Factory reset method"
-  default PRST_ZB_FACTORY_RESET_VIA_DOUBLE_RESET
+  default PRST_ZB_FACTORY_RESET_VIA_SW1
 
 config PRST_ZB_FACTORY_RESET_VIA_DOUBLE_RESET
   bool "Double resetting factory resets the device."
 
 config PRST_ZB_FACTORY_RESET_VIA_RESET_PIN
   bool "Resetting via the reset pin will factory reset the device. Power cycling through battery replacement will not."
+
+config PRST_ZB_FACTORY_RESET_VIA_SW1
+  bool "Resetting while pressing and holding SW1 for 5 seconds will factory reset the device. Only available on v2.0.0+ hardware revisions."
 
 endchoice  # PRST_ZB_FACTORY_RESET_METHOD
 

--- a/code/nrf-connect/samples/zigbee/prj.conf
+++ b/code/nrf-connect/samples/zigbee/prj.conf
@@ -56,3 +56,7 @@ CONFIG_FILE_SYSTEM_LITTLEFS=y
 
 # Uncomment for debug log level.
 # CONFIG_LOG_DEFAULT_LEVEL=4
+
+# Factory reset method selection. Only hardware revision 2.0.0+ has button SW1. Earlier
+# revisions must select a different method. See Kconfig for options.
+# CONFIG_PRST_ZB_FACTORY_RESET_VIA_SW1=y

--- a/code/nrf-connect/samples/zigbee/src/factory_reset.c
+++ b/code/nrf-connect/samples/zigbee/src/factory_reset.c
@@ -1,6 +1,7 @@
 #include "factory_reset.h"
 
 #include <hal/nrf_power.h>
+#include <prstlib/button.h>
 #include <prstlib/led.h>
 #include <zephyr/logging/log.h>
 #include <zigbee/zigbee_app_utils.h>
@@ -10,8 +11,8 @@
 LOG_MODULE_REGISTER(factory_reset, CONFIG_LOG_DEFAULT_LEVEL);
 
 static int factory_reset() {
-  // TODO: consider zb_bdb_reset_via_local_action(/*param=*/0);
-  zigbee_erase_persistent_storage(/*erase=*/true);
+  LOG_WRN("Factory resetting device");
+  zb_bdb_reset_via_local_action(/*param=*/0);
   return 0;
 }
 
@@ -37,10 +38,35 @@ static int factory_reset_if_reset_via_reset_pin() {
 }
 #endif  // CONFIG_PRST_ZB_FACTORY_RESET_VIA_RESET_PIN
 
+#if CONFIG_PRST_ZB_FACTORY_RESET_VIA_SW1
+
+static void timer_do_reset(zb_uint8_t unused_param) {
+  LOG_WRN("SW1 button was pressed for 5 seconds, factory resetting device");
+  prst_led_flash(/*times=*/5);
+  factory_reset();
+}
+
+static void sw1_factory_reset_check_timer_cb(struct k_timer *timer_id) {
+  if (!prst_button_poll(PRST_BUTTON_SW1)) {
+    LOG_DBG("SW1 button was released, will not factory reset device");
+    return;
+  }
+  ZB_SCHEDULE_APP_CALLBACK(timer_do_reset, /*param=*/0);
+}
+
+K_TIMER_DEFINE(sw1_factory_reset_check_timer, sw1_factory_reset_check_timer_cb, NULL);
+#endif
+
 int prst_zb_factory_reset_check() {
 #if CONFIG_PRST_ZB_FACTORY_RESET_VIA_DOUBLE_RESET
   return prst_detect_double_reset(double_reset_handler);
 #elif CONFIG_PRST_ZB_FACTORY_RESET_VIA_RESET_PIN
   return factory_reset_if_reset_via_reset_pin();
-#endif  // CONFIG_PRST_ZB_FACTORY_RESET_VIA_RESET_PIN
+#elif CONFIG_PRST_ZB_FACTORY_RESET_VIA_SW1
+  if (prst_button_poll(PRST_BUTTON_SW1)) {
+    LOG_DBG("SW1 pressed. Scheduling timer");
+    k_timer_start(&sw1_factory_reset_check_timer, K_SECONDS(5), K_NO_WAIT);
+  }
+#endif
+  return 0;
 }

--- a/code/nrf-connect/samples/zigbee/src/factory_reset.c
+++ b/code/nrf-connect/samples/zigbee/src/factory_reset.c
@@ -39,7 +39,6 @@ static int factory_reset_if_reset_via_reset_pin() {
 #endif  // CONFIG_PRST_ZB_FACTORY_RESET_VIA_RESET_PIN
 
 #if CONFIG_PRST_ZB_FACTORY_RESET_VIA_SW1
-
 static void timer_do_reset(zb_uint8_t unused_param) {
   LOG_WRN("SW1 button was pressed for 5 seconds, factory resetting device");
   prst_led_flash(/*times=*/5);


### PR DESCRIPTION
With this config set, resetting while pressing and holding the SW1 button for 5 seconds will factory reset the device.