### PR TITLE
[ble sample] Sets BTHome V2 as the default encoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This repository also hosts a few different firmware samples for b-parasite.
 
 |Sample|Description|Extra Documentation|
 |---|---|---|
-|[samples/ble](./code/nrf-connect/samples/ble)|This is the most battle-tested and useful firmware. It periodically reads all sensors and broadcast them via Bluetooth Low Energy (BLE). It works with [Home Assistant](https://www.home-assistant.io/) out of the box. |[Docs](./code/nrf-connect/samples/ble/README.md)|
+|[samples/ble](./code/nrf-connect/samples/ble)|This is the most battle-tested and useful firmware. It periodically reads all sensors and broadcast them via Bluetooth Low Energy (BLE). It works with [Home Assistant](https://www.home-assistant.io/) + [BTHome](https://bthome.io/) out of the box. |[Docs](./code/nrf-connect/samples/ble/README.md)|
 |[samples/zigbee](./code/nrf-connect/samples/zigbee)| An experimental/educational/exploratory basic Zigbee sample built on [nRF Connect + ZBOSS](https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/ug_zigbee.html). It integrates with [Home Assistant](https://www.home-assistant.io/) via [ZHA](https://www.home-assistant.io/integrations/zha) or [Zigbee2MQTT](https://www.zigbee2mqtt.io/). |[Docs](./code/nrf-connect/samples/zigbee/README.md)|
 |[samples/blinky](./code/nrf-connect/samples/blinky)| The classic "Hello, world" |-|
 |[samples/soil_read_loop](./code/nrf-connect/samples/soil_read_loop)| Reads the soil moisture sensor on a loop. Useful for experimenting and calibrating the sensor. |-|

--- a/code/nrf-connect/samples/ble/Kconfig
+++ b/code/nrf-connect/samples/ble/Kconfig
@@ -20,7 +20,7 @@ config PRST_BLE_MAX_ADV_INTERVAL
 
 choice PRST_BLE_ENCODING
 	prompt "b-parasite BLE encoding"
-	default PRST_BLE_ENCODING_BPARASITE_V2
+	default PRST_BLE_ENCODING_BTHOME_V2
 
 config PRST_BLE_ENCODING_BPARASITE_V2
 	bool "Uses the custom b-parasite protocol v2 for encoding advertising packets"

--- a/code/nrf-connect/samples/ble/README.md
+++ b/code/nrf-connect/samples/ble/README.md
@@ -22,11 +22,10 @@ This is what a typical deployment with BTHome looks like:
 ![Topology with BTHome + Home Assistant](./media/drawings/ble-bthome-encoding.png)
 
 There are two versions of BTHome encodings supported by this sample:
+* `PRST_BLE_ENCODING_BTHOME_V2=y` (**default**) uses the [BTHome V2](https://bthome.io/format/), supported by Home Assistant since version `2022.12`
 * `PRST_BLE_ENCODING_BTHOME_V1=y` uses the [legacy BTHome V1](https://bthome.io/v1/), which was briefly in use
-* `PRST_BLE_ENCODING_BTHOME_V2=y` uses the [BTHome V2](https://bthome.io/format/), which is not yet (as of early Dec/2022) in the stable Home Assistant release. This will soon become the default.
-
 #### b-parasite Encoding
-`PRST_BLE_ENCODING_BPARASITE_V2=y` selects the "legacy" encoding, used historically inn this project. This is the encoding that the [`b_parasite`](https://esphome.io/components/sensor/b_parasite.html) ESPHome component understands.
+`PRST_BLE_ENCODING_BPARASITE_V2=y` selects the legacy encoding, used historically in this project. This is the encoding that the [`b_parasite`](https://esphome.io/components/sensor/b_parasite.html) ESPHome component understands.
 
 With this encoding and a ESPHome + `b_parasite` component, this is an usual deployment topology:
 


### PR DESCRIPTION
This change has been planned for a while, and BTHome v2 + Home Assistant is currently the most convenient, hassle-free and maintained way to interface with the BLE sample.