### PR TITLE
Fix nRF52833 flash partitions

### DIFF
--- a/code/nrf-connect/prstlib/boards/arm/bparasite_nrf52833/bparasite_nrf52833.dts
+++ b/code/nrf-connect/prstlib/boards/arm/bparasite_nrf52833/bparasite_nrf52833.dts
@@ -135,7 +135,6 @@
 
 
 &flash0 {
-
 	partitions {
 		compatible = "fixed-partitions";
 		#address-cells = <1>;
@@ -143,33 +142,23 @@
 
 		boot_partition: partition@0 {
 			label = "mcuboot";
-			reg = <0x00000000 0x0000C000>;
+			reg = <0x000000000 0xC000>;
 		};
 		slot0_partition: partition@c000 {
 			label = "image-0";
-			reg = <0x0000C000 0x00067000>;
+			reg = <0x0000C000 0x32000>;
 		};
-		slot1_partition: partition@73000 {
+		slot1_partition: partition@3e000 {
 			label = "image-1";
-			reg = <0x00073000 0x00067000>;
+			reg = <0x0003E000 0x32000>;
 		};
-		scratch_partition: partition@da000 {
+		scratch_partition: partition@70000 {
 			label = "image-scratch";
-			reg = <0x000da000 0x0001e000>;
+			reg = <0x00070000 0xA000>;
 		};
-
-		/*
-		 * The flash starting at 0x000f8000 and ending at
-		 * 0x000fffff is reserved for use by the application.
-		 */
-
-		/*
-		 * Storage partition will be used by FCB/LittleFS/NVS
-		 * if enabled.
-		 */
-		storage_partition: partition@f8000 {
+		storage_partition: partition@7a000 {
 			label = "storage";
-			reg = <0x000f8000 0x00008000>;
+			reg = <0x0007A000 0x00006000>;
 		};
 	};
 };


### PR DESCRIPTION
The nRF52833 has only 512 kB of flash. The .dts file was incorrect, as a product of having it forked from the nRF52840 .dts file, which has 1 MB of flash.

Since we use just a little bit of flash, we luckily never ran into this issue.

The new, correct partitions are closely related to the [nrf52833dk](https://github.com/zephyrproject-rtos/zephyr/blob/ec527228613e2768caaddedaa5cdea04951d3a06/boards/arm/nrf52833dk_nrf52833/nrf52833dk_nrf52833.dts#L215).