### PR TITLE
Only read positive voltages in adc.c

### DIFF
--- a/code/nrf-connect/prstlib/src/adc.c
+++ b/code/nrf-connect/prstlib/src/adc.c
@@ -108,6 +108,7 @@ static int read_adc_spec(const struct adc_dt_spec* spec, prst_adc_read_t* out) {
 
   int32_t val_mv = buf;
   RET_IF_ERR(adc_raw_to_millivolts_dt(spec, &val_mv));
+  val_mv = MAX(0, val_mv);
 
   out->raw = buf;
   out->millivolts = val_mv;


### PR DESCRIPTION
The ADC sometimes responds with negative voltages read on the ADC input due to noise. This can lead to very high illuminance readings at night (4095 << 4 to be exact due to two's complement :) ). This commit caps ADC readings at 0.