### PR TITLE
Adjusting sleep durations to be milliseconds. Needed for FCC 15b testing.

### DIFF
--- a/.github/workflows/b-parasite.yml
+++ b/.github/workflows/b-parasite.yml
@@ -86,7 +86,7 @@ jobs:
           sample-dir: code/nrf-connect/samples/ble
           board: bparasite_${{ matrix.soc }}
           revision: ${{ matrix.revision }}
-          cmake-extra: -DCONFIG_PRST_BLE_ENCODING_BTHOME_V2=y -DCONFIG_PRST_SLEEP_DURATION_SEC=1 -DCONFIG_PRSTLIB_LOG_LEVEL_DBG=y
+          cmake-extra: -DCONFIG_PRST_BLE_ENCODING_BTHOME_V2=y -DCONFIG_PRST_SLEEP_DURATION_MSEC=1000 -DCONFIG_PRSTLIB_LOG_LEVEL_DBG=y
           output-bin: ble_${{ matrix.soc }}_${{ matrix.revision }}_debug.hex
 
   build-zigbee:

--- a/code/nrf-connect/samples/ble/Kconfig
+++ b/code/nrf-connect/samples/ble/Kconfig
@@ -4,11 +4,11 @@ rsource "../../prstlib/Kconfig"
 
 config PRST_SLEEP_DURATION_MSEC
 	int "Sleep duration in milliseconds"
-	default 600
+	default 600000
 
 config PRST_BLE_ADV_DURATION_MSEC
 	int "Advertising duration in milliseconds"
-	default 1
+	default 1000
 
 config PRST_BLE_MIN_ADV_INTERVAL
 	int "Minimum advertising interval in milliseconds"

--- a/code/nrf-connect/samples/ble/Kconfig
+++ b/code/nrf-connect/samples/ble/Kconfig
@@ -2,12 +2,12 @@
 source "Kconfig.zephyr"
 rsource "../../prstlib/Kconfig"
 
-config PRST_SLEEP_DURATION_SEC
-	int "Sleep duration in seconds"
+config PRST_SLEEP_DURATION_MSEC
+	int "Sleep duration in milliseconds"
 	default 600
 
-config PRST_BLE_ADV_DURATION_SEC
-	int "Advertising duration in seconds"
+config PRST_BLE_ADV_DURATION_MSEC
+	int "Advertising duration in milliseconds"
 	default 1
 
 config PRST_BLE_MIN_ADV_INTERVAL

--- a/code/nrf-connect/samples/ble/README.md
+++ b/code/nrf-connect/samples/ble/README.md
@@ -8,7 +8,7 @@ Available configurations and their default values are in [`Kconfig`](./Kconfig).
 To save energy, the board spends most of the time in a "deep sleep" state, in which most peripherals and radio are completely turned off. The period of sleep is controlled by the `PRST_SLEEP_DURATION_SEC` config.
 
 ### Advertising Duration
-When it wakes up, the sample reads all sensors and keep broadcasting advertising packets for `PRST_BLE_ADV_DURATION_SEC` before going back to sleep.
+When it wakes up, the sample reads all sensors and keep broadcasting advertising packets for `PRST_BLE_ADV_DURATION_MSEC` before going back to sleep.
 
 ### Advertising Packet Encoding
 There are different ways to encode the sensor data in a BLE advertising packet.

--- a/code/nrf-connect/samples/ble/prj.conf
+++ b/code/nrf-connect/samples/ble/prj.conf
@@ -21,7 +21,7 @@ CONFIG_ASSERT=y
 
 # Application config - see all options in Kconfig.
 # CONFIG_PRST_BLE_ENCODING_BTHOME_V2=y
-# CONFIG_PRST_SLEEP_DURATION_SEC=1
+# CONFIG_PRST_SLEEP_DURATION_MSEC=1000
 
 # prstlib config - ser all options in prstlib/Kconfig.
 # CONFIG_PRSTLIB_LOG_LEVEL_DBG=y

--- a/code/nrf-connect/samples/ble/src/main.c
+++ b/code/nrf-connect/samples/ble/src/main.c
@@ -26,7 +26,7 @@ static int prst_loop(prst_sensors_t *sensors) {
   RET_IF_ERR(prst_sensors_read_all(sensors));
   RET_IF_ERR(prst_ble_adv_set_data(sensors));
   RET_IF_ERR(prst_ble_adv_start());
-  k_sleep(K_SECONDS(CONFIG_PRST_BLE_ADV_DURATION_SEC));
+  k_msleep(CONFIG_PRST_BLE_ADV_DURATION_MSEC);
   RET_IF_ERR(prst_ble_adv_stop());
   return 0;
 }
@@ -37,6 +37,6 @@ int main(void) {
   prst_sensors_t sensors;
   while (true) {
     __ASSERT(!prst_loop(&sensors), "Error in prst_loop()");
-    k_sleep(K_SECONDS(CONFIG_PRST_SLEEP_DURATION_SEC));
+    k_msleep(CONFIG_PRST_SLEEP_DURATION_MSEC);
   }
 }


### PR DESCRIPTION
As part of unintentional radiator testing, I needed to reduce the loop so that the device is constantly sending data. These changes increase the resolution of the BLE advertizment and loop sleeps allowing me to create a build with a 20ms sleep.

I plan on sending the devices to the lab next week. First time going through this process, if I'm doing a dumb please speak up.