### PR TITLE
Update board.cmake to use nrfutil for flashing

### DIFF
--- a/code/nrf-connect/prstlib/boards/bparasite/board.cmake
+++ b/code/nrf-connect/prstlib/boards/bparasite/board.cmake
@@ -9,7 +9,7 @@ board_runner_args(pyocd "--target=nrf52840" "--frequency=4000000")
 endif()
 
 # set(OPENOCD_NRF5_SUBFAMILY "nrf52")
-include(${ZEPHYR_BASE}/boards/common/nrfjprog.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/nrfutil.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/openocd-nrf5.board.cmake)


### PR DESCRIPTION
nrfjprog is deprecated and replaced by nrfutil