### PR TITLE
fix: SHTC3 sensor link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ b-parasite is an open source soil moisture and ambient temperature/humidity/ligh
 
 # Features
 * Capacitive Soil moisture sensor - see [this blog post](https://rbaron.net/blog/2021/04/05/How-capacitive-soil-moisture-sensors-work.html), [this Twitter thread](https://twitter.com/rbaron_/status/1367182806368071685), and [this post](https://wemakethings.net/2012/09/26/capacitance_measurement/) for nice resources on how they work
-* Air temperature and humidity sensor using a [Sensirion's SHTC3](https://www.sensirion.com/en/environmental-sensors/humidity-sensors/digital-humidity-sensor-shtc3-our-new-standard-for-consumer-electronics/)
+* Air temperature and humidity sensor using a [Sensirion's SHTC3](https://sensirion.com/media/documents/643F9C8E/63A5A436/Datasheet_SHTC3.pdf)
 * Light sensor using an [ALS-PT19](https://en.everlight.com/wp-content/plugins/ItemRelationship/product_files/pdf/ALS-PT19-315C-L177-TR8_V8.pdf) phototransistor
 * Powered by a common CR2032 coin cell, potentially for over two years
 * Support for [nRF52840](https://www.nordicsemi.com/products/nrf52840) and [nRF52833](https://www.nordicsemi.com/products/nrf52833) modules


### PR DESCRIPTION
Link directly to the sensor datasheet as the currently linked page has been removed and leads to a 404 page.